### PR TITLE
Bugfix: Updated name in DynamoDB Configuration for NotesTable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -238,7 +238,7 @@ Resources:
   # DynamoDB Configuration
   #-----------------------------------------------------
   
-  PlaylistsTable:
+  NotesTable:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:


### PR DESCRIPTION
Config had incorrect name causing failure with deployment for #3

