### PR TITLE
New GH Action for `deploy` branches

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,7 +10,7 @@ on:
 env:
 
   # STUDENTS: Set these environment variables
-  API_BASE_URL: https://i48vsoyvv9.execute-api.us-east-2.amazonaws.com/Prod/
+  API_BASE_URL: https://mmuotk1tuc.execute-api.us-east-2.amazonaws.com/Prod/
   COGNITO_DOMAIN: project-noteworthy-cito-mcclure
   COGNITO_REDIRECT_SIGNIN: https://d3r2t0o2s8l90u.cloudfront.net
   COGNITO_REDIRECT_SIGNOUT: https://d3r2t0o2s8l90u.cloudfront.net


### PR DESCRIPTION
Created a way to test deployment configurations without having to merge to `main` to kickoff remote deployment. Branches that begin with `deploy` will also automatically kickoff `build-and-package-main` and `deploy-to-aws` jobs.

Bugfix: Updated new `API_BASE_URL` env variable value to reflect new stack made in #15 