### PR TITLE
Bug fix for punctuation on wrong side of note preview buttons

### DIFF
--- a/web/static_assets/css/style.css
+++ b/web/static_assets/css/style.css
@@ -126,11 +126,7 @@ body {
 }
 
 /* ----------------------- Note Preview Area ----------------------- */
-.note-previews-container {
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
-    align-items: center;
+.note-previews-container-scroll {
     margin-bottom: 15px;
     height: 490px;
     max-height: 490px;
@@ -155,6 +151,14 @@ body {
     mask-position: center;
     mask-repeat:no-repeat;
     mask-composite: intersect;
+}
+
+.note-previews-container {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    align-items: center;
+    direction: ltr;
 }
 
 .note-previews-container .button {

--- a/web/static_assets/index.html
+++ b/web/static_assets/index.html
@@ -37,9 +37,11 @@
                   </ul>
               </div>
             </div>
-            
-            <!-- ************************ Primary Note View ************************ -->
-            <div class="note-previews-container"></div>
+
+            <!-- ************************ Note Preview Area ************************ -->
+            <div class="note-previews-container-scroll">
+              <div class="note-previews-container"></div>
+            </div>
           </div>
 
           <div class="col"></div>


### PR DESCRIPTION
Bug fixed. Added `div` wrapper (`class=note-preview-container-scroll`) to just house scroll functionality so direction could be left to right for note preview buttons inside `note-preview-container` `div`